### PR TITLE
Commit to solve the error : NameError: name 'pkl_out' is not defined

### DIFF
--- a/habiticaTodo/twoWaySync.py
+++ b/habiticaTodo/twoWaySync.py
@@ -137,7 +137,7 @@ for tid in expired_tids:
     matchDict.pop(tid)
 
 pkl_file = open('twoWay_matchDict.pkl','wb')
-pkl_out - pickle.Pickler(pkl_file, -1)
+pkl_out = pickle.Pickler(pkl_file, -1)
 pkl_out.dump(matchDict)
 pkl_file.close()
 tod_user.commit()


### PR DESCRIPTION
Hello, 

i have an error when i try to run the script habiticaTodo/twoWaySync.py

<Response [401]>
Traceback (most recent call last):
  File "twoWaySync.py", line 140, in <module>
    pkl_out - pickle.Pickler(pkl_file, -1)
NameError: name 'pkl_out' is not defined

reading the code i see an little problem on the line 

pkl_out - pickle.Pickler(pkl_file, -1)

And i change this to 

pkl_out = pickle.Pickler(pkl_file, -1)